### PR TITLE
send integer timestamp, for compatibility to Zabbix 3

### DIFF
--- a/mqtt-zabbix.py
+++ b/mqtt-zabbix.py
@@ -179,7 +179,8 @@ def process_message(msg):
         # should we sanitize input or just accept it as is?
         send_to_zabbix([Metric(KEYHOST,
                         KeyMap.mapdict[msg.topic],
-                        msg.payload)],
+                        msg.payload,
+                        time.strftime("%s"))],
                         ZBXSERVER,
                         ZBXPORT)
     else:


### PR DESCRIPTION
At least Zabbix 3.2 doesn't seem to accept values without a proper timestamp. With this small change, it works for me.