### PR TITLE
README Changes, MQTT is working with new paho version, hostname added in keys example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sudo python setup.py install
 # Install MQTT Zabbix
 ```
 mkdir /etc/mqtt-zabbix/
-git clone git://github.com/kylegordon/mqtt-zabbix.git /usr/local/mqtt-zabbix/
+git clone git://github.com/lfsousa/mqtt-zabbix.git /usr/local/mqtt-zabbix/
 cp /usr/local/mqtt-zabbix/mqtt-zabbix.cfg.example /etc/mqtt-zabbix/mqtt-zabbix.cfg
 cp /usr/local/mqtt-zabbix/mqtt-zabbix.init /etc/init.d/mqtt-zabbix
 update-rc.d mqtt-zabbix defaults

--- a/README.md
+++ b/README.md
@@ -3,16 +3,22 @@ SUMMARY
 
 A small daemon to listen for particular MQTT messages, and relay them to a Zabbix server
 
-INSTALL
+INSTALL DEPENDENCES
 =======
 
+```
 sudo apt-get install python-mosquitto git python-pip python-simplejson
 sudo pip install zbxsend
+```
 # Alternatively this...
-#git clone https://github.com/pistolero/zbxsend /tmp/zbxsend
-#cd /tmp/zbxsend
-#sudo python setup.py install
+```
+git clone https://github.com/pistolero/zbxsend /tmp/zbxsend
+cd /tmp/zbxsend
+sudo python setup.py install
+```
 
+# Install MQTT Zabbix
+```
 mkdir /etc/mqtt-zabbix/
 git clone git://github.com/kylegordon/mqtt-zabbix.git /usr/local/mqtt-zabbix/
 cp /usr/local/mqtt-zabbix/mqtt-zabbix.cfg.example /etc/mqtt-zabbix/mqtt-zabbix.cfg
@@ -23,11 +29,13 @@ cp /usr/local/mqtt-zabbix/mqtt-zabbix.default /etc/default/mqtt-zabbix
 cp /usr/local/mqtt-zabbix/keys.csv.example /etc/mqtt-zabbix/keys.csv
 ## Edit /etc/mqtt-zabbix/keys.csv to suit. Be sure to avoid spaces, and keep it as one key per topic
 /etc/init.d/mqtt-zabbix start
+```
 
 CONFIGURE
 =========
 
 Configuration is stored in /etc/mqtt-zabbix/mqtt-zabbix.cfg
+
 Message topics are mapped to Zabbix key names, and are stored in /etc/mqtt-zabbix/keys.csv
 When setting up a Zabbix item, ensure you use item type of Zabbix trapper, and check the "Type of information" field is defined correctly. MQTT can transport all sorts of information, and will happily try to deliver a string to your integer data type!
 zbx_mqtt_template.xml is an example Zabbix template

--- a/keys.csv.example
+++ b/keys.csv.example
@@ -1,4 +1,4 @@
-/bishopbriggs/gordonhouse/electricity/watts,mqtt.house.watts
-/bishopbriggs/gordonhouse/kitchen/temperature,mqtt.kitchen.temperature
-/bishopbriggs/gordonhouse/kitchen/freezer/temperature,mqtt.freezer.temperature
-/bishopbriggs/gordonhouse/kitchen/fridge/temperature,mqtt.fridge.temperature
+/bishopbriggs/gordonhouse/electricity/watts,mqtt.house.watts::hostname
+/bishopbriggs/gordonhouse/kitchen/temperature,mqtt.kitchen.temperature::hostname
+/bishopbriggs/gordonhouse/kitchen/freezer/temperature,mqtt.freezer.temperature::hostname
+/bishopbriggs/gordonhouse/kitchen/fridge/temperature,mqtt.fridge.temperature::hostname

--- a/mqtt-zabbix.py
+++ b/mqtt-zabbix.py
@@ -79,7 +79,7 @@ def on_unsubscribe(mosq, obj, mid):
     logging.debug("Unsubscribe with mid " + str(mid) + " received.")
 
 
-def on_connect(mosq, obj, result_code):
+def on_connect(self, mosq, obj, result_code):
     """
     Handle connections (or failures) to the broker.
     This is called after the client has received a CONNACK message
@@ -173,7 +173,7 @@ def process_message(msg):
 	    msg.payload = 1
         if msg.payload == "OFF":
             msg.payload = 0
-        zbxKey = KeyMap.mapdict[msg.topic];
+        zbxKey = KeyMap.mapdict[msg.topic]
         (zbxKey,zbxHost) =zbxKey.split("::")
   	if zbxHost == "": 
 	    zbxHost = KEYHOST	


### PR DESCRIPTION
Some functions are outdated. In order to work with new paho version, I've updated the on message function